### PR TITLE
Add post-commit broadcast queue and enforce non-mutating Bubble contributions

### DIFF
--- a/areas/rantamuta/scripts/items/ritualPutTarget.js
+++ b/areas/rantamuta/scripts/items/ritualPutTarget.js
@@ -27,6 +27,12 @@ const {
   getPutPolicy,
   isPutToIndirectTarget,
 } = require('../helpers/putPolicy');
+const { evaluateExitGate } = require('../helpers/exitGate');
+
+const CRYPT_ROOM_REFERENCE = 'rantamuta:bell_crypt';
+const RITUAL_HUM_MESSAGE = 'A low, resonant hum fills the tower, wavering at its edges before steadying.';
+const RITUAL_AREA_GRIND_MESSAGE = 'There is a low grinding sound from the base of the bell tower.';
+const RITUAL_CRYPT_GRIND_MESSAGE = 'A stone slab on the floor moves aside with a low grinding sound, revealing a staircase descending into darkness.';
 
 /**
  * Normalize entity refs and metadata values so comparisons are predictable.
@@ -67,6 +73,167 @@ function inventoryValues(entity) {
   }
 
   return [];
+}
+
+/**
+ * Read all items from the global manager in deterministic iteration order.
+ *
+ * @param {*} state
+ * @returns {Array<*>}
+ */
+function allItems(state) {
+  const manager = state && state.ItemManager;
+  const items = manager && manager.items;
+  return inventoryValues({ inventory: items });
+}
+
+/**
+ * @param {*} state
+ * @param {string} entityRef
+ * @returns {* | null}
+ */
+function findItemByEntityRef(state, entityRef) {
+  const needle = normalizeRef(entityRef);
+  if (!needle) {
+    return null;
+  }
+
+  for (const item of allItems(state)) {
+    if (normalizeRef(item && item.entityReference) === needle) {
+      return item;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {*} state
+ * @returns {* | null}
+ */
+function findCryptRoom(state) {
+  const roomManager = state && state.RoomManager;
+  if (!roomManager || typeof roomManager.getRoom !== 'function') {
+    return null;
+  }
+
+  return roomManager.getRoom(CRYPT_ROOM_REFERENCE);
+}
+
+/**
+ * @param {*} room
+ * @returns {* | null}
+ */
+function findDownExit(room) {
+  if (!room || typeof room !== 'object') {
+    return null;
+  }
+
+  const exits = typeof room.getExits === 'function'
+    ? room.getExits()
+    : room.exits;
+  if (!Array.isArray(exits)) {
+    return null;
+  }
+
+  for (const exit of exits) {
+    if (exit && typeof exit === 'object' && normalizeRef(exit.direction) === 'down') {
+      return exit;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {*} state
+ * @returns {Array<{ containerRef: string, itemRef: string }>}
+ */
+function ritualRequirements(state) {
+  const cryptRoom = findCryptRoom(state);
+  const downExit = findDownExit(cryptRoom);
+  const metadata = downExit && typeof downExit === 'object' && downExit.metadata && typeof downExit.metadata === 'object'
+    ? downExit.metadata
+    : null;
+  const gate = metadata && metadata.gate && typeof metadata.gate === 'object'
+    ? metadata.gate
+    : null;
+  const requiredPlacements = gate && Array.isArray(gate.requiredPlacements)
+    ? gate.requiredPlacements
+    : [];
+
+  return requiredPlacements
+    .map(entry => ({
+      containerRef: normalizeRef(entry && entry.containerRef),
+      itemRef: normalizeRef(entry && entry.itemRef),
+    }))
+    .filter(entry => entry.containerRef && entry.itemRef);
+}
+
+/**
+ * @param {*} container
+ * @param {string} itemRef
+ * @returns {boolean}
+ */
+function containerHasItemRef(container, itemRef) {
+  const needle = normalizeRef(itemRef);
+  if (!container || typeof container !== 'object' || !needle) {
+    return false;
+  }
+
+  return inventoryValues(container).some(item => normalizeRef(item && item.entityReference) === needle);
+}
+
+/**
+ * Determine whether this exact successful `put` will open the crypt descent.
+ *
+ * This check is read-only and predictive:
+ * - It verifies the gate is currently closed.
+ * - It then evaluates required placements, treating the current planned put
+ *   (directTarget -> indirectTarget) as satisfied even before commit executes.
+ *
+ * @param {*} state
+ * @param {*} context
+ * @returns {boolean}
+ */
+function willOpenDescentAfterCurrentPut(state, context) {
+  const requirements = ritualRequirements(state);
+  if (!requirements.length) {
+    return false;
+  }
+
+  const cryptRoom = findCryptRoom(state);
+  const downExit = findDownExit(cryptRoom);
+  if (!downExit) {
+    return false;
+  }
+
+  const gateStatus = evaluateExitGate(state, downExit);
+  if (!gateStatus || gateStatus.ok !== false) {
+    return false;
+  }
+
+  const entityResolution = context && context.entityResolution && typeof context.entityResolution === 'object'
+    ? context.entityResolution
+    : null;
+  if (!entityResolution || entityResolution.ruleKey !== 'directIndirect') {
+    return false;
+  }
+
+  const directRef = normalizeRef(entityResolution.directTarget && entityResolution.directTarget.entityReference);
+  const indirectRef = normalizeRef(entityResolution.indirectTarget && entityResolution.indirectTarget.entityReference);
+  if (!directRef || !indirectRef) {
+    return false;
+  }
+
+  return requirements.every(requirement => {
+    if (requirement.containerRef === indirectRef && requirement.itemRef === directRef) {
+      return true;
+    }
+
+    const container = findItemByEntityRef(state, requirement.containerRef);
+    return containerHasItemRef(container, requirement.itemRef);
+  });
 }
 
 /**
@@ -271,6 +438,8 @@ module.exports = {
        * Responsibilities:
        * - After command passes validation, optionally add a flavor line
        *   (for example "The cracked bell hums with a low resonance.").
+       * - If this put completes the Bell Tower ritual, enqueue post-commit
+       *   area/room broadcasts. Delivery stays dispatcher-owned.
        * - Do not mutate world state here.
        * - Return null when no contribution should be added.
        */
@@ -301,11 +470,39 @@ module.exports = {
         }
 
         // Return data-only bubble contribution for dispatch/render.
-        return {
+        const contribution = {
           render: {
             lines: [policy.successRender],
           },
         };
+
+        if (willOpenDescentAfterCurrentPut(state, context)) {
+          contribution.postCommit = [
+            {
+              type: 'broadcast',
+              audience: 'area',
+              targetSelector: 'currentArea',
+              message: RITUAL_HUM_MESSAGE,
+            },
+            {
+              type: 'broadcast',
+              audience: 'areaExceptTargets',
+              targetSelector: 'currentArea',
+              exceptSelector: 'targetsByRoomRef',
+              exceptRoomRef: CRYPT_ROOM_REFERENCE,
+              message: RITUAL_AREA_GRIND_MESSAGE,
+            },
+            {
+              type: 'broadcast',
+              audience: 'room',
+              targetSelector: 'roomByRef',
+              targetRoomRef: CRYPT_ROOM_REFERENCE,
+              message: RITUAL_CRYPT_GRIND_MESSAGE,
+            },
+          ];
+        }
+
+        return contribution;
       };
 
       // Initialize description immediately on spawn so room/look text starts in

--- a/areas/rantamuta/scripts/rooms/bellCryptGate.js
+++ b/areas/rantamuta/scripts/rooms/bellCryptGate.js
@@ -1,19 +1,10 @@
 // @ts-check
 'use strict';
 
-const { Broadcast } = require('ranvier');
 const { evaluateExitGate } = require('../helpers/exitGate');
 
 const RUNES_DORMANT_DESCRIPTION = 'Ancient runes curl around the basin lip, each line cut with unnerving precision.';
 const RUNES_GLOWING_DESCRIPTION = 'Ancient runes curl around the basin lip, now lit by an ethereal glow that wavers like breath.';
-const RITUAL_HUM_MESSAGE = 'A low, resonant hum fills the tower, wavering at its edges before steadying.';
-const RITUAL_AREA_GRIND_MESSAGE = 'There is a low grinding sound from the base of the bell tower.';
-const RITUAL_CRYPT_GRIND_MESSAGE = 'A stone slab on the floor moves aside with a low grinding sound, revealing a staircase descending into darkness.';
-const RITUAL_TARGET_REFS = [
-  'rantamuta:crackedBell',
-  'rantamuta:reliquary',
-  'rantamuta:stoneBasin',
-];
 
 /**
  * @param {*} value
@@ -45,28 +36,6 @@ function valuesAsArray(collection) {
   }
 
   return [];
-}
-
-/**
- * @param {*} state
- * @param {string} entityRef
- * @returns {* | null}
- */
-function findItemByEntityRef(state, entityRef) {
-  const targetRef = normalizeRef(entityRef);
-  if (!targetRef) {
-    return null;
-  }
-
-  const manager = state && state.ItemManager;
-  const items = manager && manager.items;
-  for (const item of valuesAsArray(items)) {
-    if (normalizeRef(item && item.entityReference) === targetRef) {
-      return item;
-    }
-  }
-
-  return null;
 }
 
 /**
@@ -248,76 +217,6 @@ function attachBasinRunesSync(room) {
 }
 
 /**
- * @param {*} room
- */
-function broadcastRitualCompletion(room) {
-  if (!room || typeof room !== 'object' || room.__ritualCompletionBroadcasted) {
-    return;
-  }
-
-  const area = room.area;
-  if (!area || typeof area.getBroadcastTargets !== 'function') {
-    return;
-  }
-
-  const cryptTargets = typeof room.getBroadcastTargets === 'function'
-    ? room.getBroadcastTargets()
-    : [];
-
-  Broadcast.sayAt(area, RITUAL_HUM_MESSAGE);
-  Broadcast.sayAtExcept(area, RITUAL_AREA_GRIND_MESSAGE, cryptTargets);
-  Broadcast.sayAt(room, RITUAL_CRYPT_GRIND_MESSAGE);
-
-  room.__ritualCompletionBroadcasted = true;
-}
-
-/**
- * @param {*} state
- * @param {*} room
- */
-function attachRitualCompletionBroadcast(state, room) {
-  for (const entityRef of RITUAL_TARGET_REFS) {
-    const target = findItemByEntityRef(state, entityRef);
-    if (!target || typeof target !== 'object' || target.__ritualCompletionWrapped) {
-      continue;
-    }
-
-    const previousAddItem = typeof target.addItem === 'function'
-      ? target.addItem
-      : null;
-    const previousRemoveItem = typeof target.removeItem === 'function'
-      ? target.removeItem
-      : null;
-
-    if (previousAddItem) {
-      target.addItem = (item) => {
-        const wasOpen = isDescentOpen(state, room);
-        const result = previousAddItem.call(target, item);
-        const isOpen = isDescentOpen(state, room);
-        if (!wasOpen && isOpen) {
-          broadcastRitualCompletion(room);
-        }
-        return result;
-      };
-    }
-
-    if (previousRemoveItem) {
-      target.removeItem = (item) => {
-        const wasOpen = isDescentOpen(state, room);
-        const result = previousRemoveItem.call(target, item);
-        const isOpen = isDescentOpen(state, room);
-        if (!wasOpen && isOpen) {
-          broadcastRitualCompletion(room);
-        }
-        return result;
-      };
-    }
-
-    target.__ritualCompletionWrapped = true;
-  }
-}
-
-/**
  * @param {*} action
  * @param {*} context
  * @returns {boolean}
@@ -382,9 +281,8 @@ module.exports = {
 
       syncRunesDetailDescription(this);
     },
-    ready: state => function onReady() {
+    ready: () => function onReady() {
       attachBasinRunesSync(this);
-      attachRitualCompletionBroadcast(state, this);
       syncRunesDetailDescription(this);
     },
   },

--- a/lib/session/command-dispatch.js
+++ b/lib/session/command-dispatch.js
@@ -5,6 +5,7 @@ const { Broadcast, Logger } = require('ranvier');
 const { parseInput } = require('../parse-input');
 const Mutator = require('./mutator');
 const EntityResolution = require('./entity-resolution');
+const PostCommitDispatch = require('./post-commit-dispatch');
 
 /** @typedef {import('ranvier/types/GameState')} GameState */
 /** @typedef {import('ranvier/types/Command')} Command */
@@ -65,7 +66,7 @@ function resolveCommand(state, commandName) {
  */
 
 /**
- * @typedef {{ ok: true, plan: MutationPlan, render?: CommandRenderPayload }} CommandSuccessResult
+ * @typedef {{ ok: true, plan: MutationPlan, render?: CommandRenderPayload, postCommit?: Array<*> }} CommandSuccessResult
  */
 
 /**
@@ -567,17 +568,18 @@ function runCaptureChecks(command, context) {
 
 /**
  * @param {*} candidate
- * @param {Array<*>} operations
  * @param {string[]} renderLines
+ * @param {Array<*>} postCommit
+ * @param {{ operationsRejected: number }} diagnostics
  */
-function consumeBubbleContribution(candidate, operations, renderLines) {
+function consumeBubbleContribution(candidate, renderLines, postCommit, diagnostics) {
   if (!candidate) {
     return;
   }
 
   if (Array.isArray(candidate)) {
     for (const entry of candidate) {
-      consumeBubbleContribution(entry, operations, renderLines);
+      consumeBubbleContribution(entry, renderLines, postCommit, diagnostics);
     }
     return;
   }
@@ -592,38 +594,44 @@ function consumeBubbleContribution(candidate, operations, renderLines) {
     ? /** @type {Record<string, *>} */ (contribution.render)
     : null;
   const hasRenderLines = !!render && Array.isArray(render.lines);
+  const hasPostCommit = Array.isArray(contribution.postCommit);
 
   if (hasOperations) {
-    operations.push(...contribution.operations);
+    diagnostics.operationsRejected += contribution.operations.length;
+    Logger.error('Bubble contribution attempted to enqueue mutation operations. Bubble may contribute render/postCommit only.');
   }
 
   if (hasRenderLines && render) {
     renderLines.push(...render.lines.map(line => String(line)));
   }
 
-  if (hasOperations || hasRenderLines) {
-    return;
+  if (hasPostCommit) {
+    postCommit.push(...contribution.postCommit);
   }
 
-  // Backward-compatible single-operation shape.
-  operations.push(contribution);
+  if (Object.prototype.hasOwnProperty.call(contribution, 'postCommit') && !hasPostCommit) {
+    Logger.error('Bubble contribution provided invalid postCommit payload (expected array). Contribution ignored.');
+  }
+
+  // Unknown payload shapes are ignored to keep bubble contributions data-only.
 }
 
 /**
  * @param {*} command
  * @param {Record<string, *>} context
- * @returns {{ operations: Array<*>, renderLines: string[] }}
+ * @returns {{ renderLines: string[], postCommit: Array<*>, operationsRejected: number }}
  */
 function collectBubbleContributions(command, context) {
   const reactions = collectPhaseFunctions(command, 'reactions', context);
-  /** @type {Array<*>} */
-  const operations = [];
   /** @type {string[]} */
   const renderLines = [];
+  /** @type {Array<*>} */
+  const postCommit = [];
+  const diagnostics = { operationsRejected: 0 };
 
   for (const reaction of reactions) {
     const result = reaction(context);
-    consumeBubbleContribution(result, operations, renderLines);
+    consumeBubbleContribution(result, renderLines, postCommit, diagnostics);
   }
 
   const entityResolution = context.entityResolution && typeof context.entityResolution === 'object'
@@ -677,27 +685,38 @@ function collectBubbleContributions(command, context) {
       relationTokenCanonical,
     };
     const result = subject.entity.bubbleEvent(action, context);
-    consumeBubbleContribution(result, operations, renderLines);
+    consumeBubbleContribution(result, renderLines, postCommit, diagnostics);
   }
 
-  return { operations, renderLines };
+  return {
+    renderLines,
+    postCommit,
+    operationsRejected: diagnostics.operationsRejected,
+  };
 }
 
 /**
- * @param {MutationPlan} basePlan
- * @param {Array<*>} bubbleOperations
- * @returns {MutationPlan}
+ * @param {*} commandPostCommit
+ * @param {Array<*>} bubblePostCommit
+ * @returns {Array<*>}
  */
-function mergePlanOperations(basePlan, bubbleOperations) {
-  if (!bubbleOperations.length) {
-    return basePlan;
+function mergePostCommitContributions(commandPostCommit, bubblePostCommit) {
+  /** @type {Array<*>} */
+  const merged = [];
+
+  if (commandPostCommit !== undefined) {
+    if (Array.isArray(commandPostCommit)) {
+      merged.push(...commandPostCommit);
+    } else {
+      Logger.error('Command returned invalid postCommit payload (expected array). Contribution ignored.');
+    }
   }
 
-  const operations = Array.isArray(basePlan && basePlan.operations)
-    ? [...basePlan.operations, ...bubbleOperations]
-    : [...bubbleOperations];
+  if (Array.isArray(bubblePostCommit) && bubblePostCommit.length > 0) {
+    merged.push(...bubblePostCommit);
+  }
 
-  return { operations };
+  return merged;
 }
 
 /**
@@ -951,13 +970,14 @@ async function handleCommand(state, session, input) {
       trace.phases.target = { ok: true };
       const bubbleContributions = collectBubbleContributions(command, phaseContext);
       trace.phases.bubble = {
-        ok: true,
-        operationsAdded: bubbleContributions.operations.length,
+        ok: bubbleContributions.operationsRejected === 0,
+        operationsAdded: 0,
+        operationsRejected: bubbleContributions.operationsRejected,
         renderLinesAdded: bubbleContributions.renderLines.length,
+        postCommitAdded: bubbleContributions.postCommit.length,
       };
-      const mergedPlan = mergePlanOperations(result.plan, bubbleContributions.operations);
       try {
-        Mutator.applyMutationPlan(state, mergedPlan);
+        Mutator.applyMutationPlan(state, result.plan);
         trace.phases.commit = { ok: true };
       } catch (err) {
         /** @type {{ stack?: string, message?: string, name?: string }} */
@@ -972,12 +992,28 @@ async function handleCommand(state, session, input) {
         }
         return trace;
       }
+
       renderSuccess(player, result, bubbleContributions.renderLines);
       const directRenderLines = result.render && Array.isArray(result.render.lines) ? result.render.lines.length : 0;
       trace.phases.render = {
         ok: true,
         linesRendered: directRenderLines + bubbleContributions.renderLines.length,
       };
+
+      const postCommitInstructions = mergePostCommitContributions(
+        result.postCommit,
+        bubbleContributions.postCommit
+      );
+      const postCommitStats = PostCommitDispatch.executePostCommitInstructions(
+        { state, player },
+        postCommitInstructions
+      );
+      trace.phases.postCommit = {
+        ok: postCommitStats.failures === 0,
+        instructionsAttempted: postCommitStats.instructionsAttempted,
+        failures: postCommitStats.failures,
+      };
+
       setSuccessOutcome(trace, 'OK');
     } else if (isCommandFailureResult(result)) {
       const message = resolveErrorMessage(command, result.error);

--- a/lib/session/player-lifecycle.js
+++ b/lib/session/player-lifecycle.js
@@ -8,6 +8,9 @@ async function loadOrCreatePlayer(state, account, username) {
   const isNew = !state.PlayerManager.exists(username);
   /** @type {InstanceType<import('ranvier').Player>} */
   let player;
+  const accountPassword = account && typeof account === 'object' && typeof account.password === 'string'
+    ? account.password
+    : '';
 
   if (!isNew) {
     player = await state.PlayerManager.loadPlayer(state, account, username);
@@ -15,7 +18,8 @@ async function loadOrCreatePlayer(state, account, username) {
     player = new Player({
       name: username,
       account,
-      room: state.Config.get('startingRoom', 'rantamuta:start'),
+      password: accountPassword,
+      room: state.Config.get('startingRoom'),
       attributes: {},
       inventory: { items: [], max: state.Config.get('defaultMaxPlayerInventory', 16) },
       quests: { active: [], completed: [] },

--- a/lib/session/post-commit-dispatch.js
+++ b/lib/session/post-commit-dispatch.js
@@ -1,0 +1,284 @@
+// @ts-check
+'use strict';
+
+const { Broadcast, Logger } = require('ranvier');
+
+const ALLOWED_AUDIENCES = new Set([
+  'player',
+  'room',
+  'area',
+  'areaExceptTargets',
+]);
+
+/**
+ * @typedef {{
+ *   type: 'broadcast',
+ *   audience: 'player' | 'room' | 'area' | 'areaExceptTargets',
+ *   message: string,
+ *   targetSelector?: 'currentPlayer' | 'currentRoom' | 'currentArea' | 'roomByRef',
+ *   targetRoomRef?: string,
+ *   exceptSelector?: 'currentRoomTargets' | 'targetsByRoomRef',
+ *   exceptRoomRef?: string,
+ * }} PostCommitBroadcastInstruction
+ */
+
+/**
+ * @typedef {{
+ *   state: *,
+ *   player: *,
+ * }} PostCommitContext
+ */
+
+/**
+ * @param {*} collection
+ * @returns {Array<*>}
+ */
+function valuesAsArray(collection) {
+  if (!collection) {
+    return [];
+  }
+
+  if (Array.isArray(collection)) {
+    return collection;
+  }
+
+  if (typeof collection.values === 'function') {
+    return Array.from(collection.values());
+  }
+
+  if (typeof collection[Symbol.iterator] === 'function') {
+    return Array.from(collection);
+  }
+
+  return [];
+}
+
+/**
+ * @param {*} player
+ * @returns {* | null}
+ */
+function currentRoom(player) {
+  return player && typeof player === 'object' && player.room && typeof player.room === 'object'
+    ? player.room
+    : null;
+}
+
+/**
+ * @param {*} player
+ * @returns {* | null}
+ */
+function currentArea(player) {
+  const room = currentRoom(player);
+  return room && typeof room === 'object' && room.area && typeof room.area === 'object'
+    ? room.area
+    : null;
+}
+
+/**
+ * @param {*} state
+ * @param {string | undefined} roomRef
+ * @returns {* | null}
+ */
+function roomByRef(state, roomRef) {
+  const ref = normalizeText(roomRef);
+  if (!ref) {
+    return null;
+  }
+
+  const roomManager = state && typeof state === 'object' && state.RoomManager && typeof state.RoomManager === 'object'
+    ? state.RoomManager
+    : null;
+  if (!roomManager || typeof roomManager.getRoom !== 'function') {
+    return null;
+  }
+
+  return roomManager.getRoom(ref);
+}
+
+/**
+ * @param {*} entity
+ * @returns {Array<*>}
+ */
+function broadcastTargets(entity) {
+  if (!entity || typeof entity !== 'object' || typeof entity.getBroadcastTargets !== 'function') {
+    return [];
+  }
+
+  return valuesAsArray(entity.getBroadcastTargets());
+}
+
+/**
+ * @param {PostCommitContext} context
+ * @param {string | undefined} selector
+ * @param {PostCommitBroadcastInstruction} instruction
+ * @returns {* | null}
+ */
+function resolveTargetSelector(context, selector, instruction) {
+  switch (selector) {
+    case 'currentPlayer':
+      return context.player || null;
+    case 'currentRoom':
+      return currentRoom(context.player);
+    case 'currentArea':
+      return currentArea(context.player);
+    case 'roomByRef':
+      return roomByRef(context.state, instruction.targetRoomRef);
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {PostCommitContext} context
+ * @param {string | undefined} selector
+ * @param {PostCommitBroadcastInstruction} instruction
+ * @returns {Array<*> | null}
+ */
+function resolveExceptSelector(context, selector, instruction) {
+  switch (selector) {
+    case 'currentRoomTargets':
+      return broadcastTargets(currentRoom(context.player));
+    case 'targetsByRoomRef':
+      return broadcastTargets(roomByRef(context.state, instruction.exceptRoomRef));
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {*} value
+ * @returns {string}
+ */
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+/**
+ * @param {PostCommitContext} context
+ * @param {PostCommitBroadcastInstruction} instruction
+ * @returns {* | null}
+ */
+function resolveAudienceTarget(context, instruction) {
+  const selector = instruction.targetSelector;
+
+  if (selector) {
+    return resolveTargetSelector(context, selector, instruction);
+  }
+
+  switch (instruction.audience) {
+    case 'player':
+      return context.player || null;
+    case 'room':
+      return currentRoom(context.player);
+    case 'area':
+    case 'areaExceptTargets':
+      return currentArea(context.player);
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {PostCommitContext} context
+ * @param {PostCommitBroadcastInstruction} instruction
+ * @returns {Array<*>}
+ */
+function resolveExceptTargets(context, instruction) {
+  const selector = instruction.exceptSelector || 'currentRoomTargets';
+  const targets = resolveExceptSelector(context, selector, instruction);
+  if (!targets) {
+    throw new TypeError(`Invalid postCommit exceptSelector "${selector}".`);
+  }
+
+  return targets;
+}
+
+/**
+ * @param {PostCommitContext} context
+ * @param {PostCommitBroadcastInstruction} instruction
+ */
+function executeBroadcastInstruction(context, instruction) {
+  if (Object.prototype.hasOwnProperty.call(instruction, 'target') ||
+    Object.prototype.hasOwnProperty.call(instruction, 'exceptTargets')) {
+    throw new TypeError('postCommit.broadcast only accepts selector fields (targetSelector/exceptSelector).');
+  }
+
+  const audience = normalizeText(instruction.audience);
+  if (!ALLOWED_AUDIENCES.has(audience)) {
+    throw new TypeError(`Unsupported postCommit audience "${audience}".`);
+  }
+
+  const message = normalizeText(instruction.message);
+  if (!message) {
+    throw new TypeError('postCommit.broadcast requires a non-empty message.');
+  }
+
+  const target = resolveAudienceTarget(context, instruction);
+  if (!target || typeof target !== 'object') {
+    throw new TypeError(`postCommit.broadcast target could not be resolved for audience "${audience}".`);
+  }
+
+  switch (audience) {
+    case 'player':
+    case 'room':
+    case 'area':
+      Broadcast.sayAt(target, message);
+      return;
+    case 'areaExceptTargets':
+      Broadcast.sayAtExcept(target, message, resolveExceptTargets(context, instruction));
+      return;
+    default:
+      throw new TypeError(`Unsupported postCommit audience "${audience}".`);
+  }
+}
+
+/**
+ * Execute post-commit delivery instructions in best-effort mode.
+ *
+ * Contract:
+ * - delivery-only v1 (`type: 'broadcast'`)
+ * - unknown/invalid instructions are logged and skipped
+ * - failures do not throw to caller and do not stop subsequent instructions
+ *
+ * @param {PostCommitContext} context
+ * @param {Array<*>} instructions
+ * @returns {{ instructionsAttempted: number, failures: number }}
+ */
+function executePostCommitInstructions(context, instructions) {
+  let instructionsAttempted = 0;
+  let failures = 0;
+
+  if (!Array.isArray(instructions) || !instructions.length) {
+    return { instructionsAttempted, failures };
+  }
+
+  for (const instruction of instructions) {
+    instructionsAttempted += 1;
+
+    try {
+      if (!instruction || typeof instruction !== 'object') {
+        throw new TypeError('postCommit instruction must be an object.');
+      }
+
+      const candidate = /** @type {Record<string, *>} */ (instruction);
+      const type = normalizeText(candidate.type);
+      if (type !== 'broadcast') {
+        throw new TypeError(`Unsupported postCommit instruction type "${type || '<empty>'}".`);
+      }
+
+      executeBroadcastInstruction(context, /** @type {PostCommitBroadcastInstruction} */ (candidate));
+    } catch (err) {
+      failures += 1;
+      const message = err && typeof err === 'object' && 'message' in err
+        ? String(err.message)
+        : 'Unknown postCommit error.';
+      Logger.error(`POST_COMMIT_DISPATCH: ${message}`);
+    }
+  }
+
+  return { instructionsAttempted, failures };
+}
+
+module.exports = {
+  executePostCommitInstructions,
+};

--- a/tests/command.dispatch.test.js
+++ b/tests/command.dispatch.test.js
@@ -1048,24 +1048,29 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('applies look bubble additions to the committed plan', async function () {
+  it('rejects bubble operations and continues success path', async function () {
     const lookDef = require('../commands/look');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
     const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
     const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
     const mutator = require(mutatorPath);
     const originalApplyMutationPlan = mutator.applyMutationPlan;
     let bubbleInvoked = false;
     const events = [];
+    const errors = [];
 
     ranvier.Broadcast.sayAt = (target, message) => {
       events.push(`render:${String(message)}`);
     };
+    ranvier.Logger.error = message => {
+      errors.push(String(message));
+    };
     mutator.applyMutationPlan = (stateArg, planArg) => {
       events.push('commit');
       assert.deepStrictEqual(planArg, {
-        operations: [{ type: 'noop' }, { type: 'noop' }, { type: 'noop' }],
+        operations: [{ type: 'noop' }],
       });
     };
 
@@ -1086,7 +1091,7 @@ describe('bundle-rantamuta command-dispatch', function () {
             (context) => {
               bubbleInvoked = true;
               assert.strictEqual(context.entityResolution.ruleKey, 'intransitive');
-              return [{ type: 'noop' }, { type: 'noop' }];
+              return { operations: [{ type: 'noop' }, { type: 'noop' }] };
             },
           ],
         },
@@ -1105,8 +1110,10 @@ describe('bundle-rantamuta command-dispatch', function () {
         'render:<bold>Bubble Room</bold>',
         'render:Bubble description',
       ]);
+      assert.ok(errors.some(message => message.includes('Bubble contribution attempted to enqueue mutation operations')));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
       mutator.applyMutationPlan = originalApplyMutationPlan;
     }
   });
@@ -1167,23 +1174,28 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('supports mixed bubble payload with operations and render lines', async function () {
+  it('rejects mixed bubble payload operations but keeps render additions', async function () {
     const lookDef = require('../commands/look');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
     const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
     const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
     const mutator = require(mutatorPath);
     const originalApplyMutationPlan = mutator.applyMutationPlan;
     const events = [];
+    const errors = [];
 
     ranvier.Broadcast.sayAt = (target, message) => {
       events.push(`render:${String(message)}`);
     };
+    ranvier.Logger.error = message => {
+      errors.push(String(message));
+    };
     mutator.applyMutationPlan = (stateArg, planArg) => {
       events.push('commit');
       assert.deepStrictEqual(planArg, {
-        operations: [{ type: 'noop' }, { type: 'noop' }],
+        operations: [{ type: 'noop' }],
       });
     };
 
@@ -1222,18 +1234,22 @@ describe('bundle-rantamuta command-dispatch', function () {
         'render:Mixed target line',
         'render:Mixed bubble line',
       ]);
+      assert.ok(errors.some(message => message.includes('Bubble contribution attempted to enqueue mutation operations')));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
       mutator.applyMutationPlan = originalApplyMutationPlan;
     }
   });
 
-  it('supports mixed bubble payload with transferItem and render lines', async function () {
+  it('rejects bubble transferItem operations and keeps world state unchanged', async function () {
     const lookDef = require('../commands/look');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
     const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
     const messages = [];
+    const errors = [];
     const inventory = new Set();
     const roomItems = new Set();
     const item = { uuid: 'spike-1', name: 'spike of heroism' };
@@ -1263,6 +1279,9 @@ describe('bundle-rantamuta command-dispatch', function () {
 
     ranvier.Broadcast.sayAt = (target, message) => {
       messages.push(String(message));
+    };
+    ranvier.Logger.error = message => {
+      errors.push(String(message));
     };
 
     try {
@@ -1294,15 +1313,17 @@ describe('bundle-rantamuta command-dispatch', function () {
 
       await handleCommand(state, { player }, 'look');
 
-      assert.strictEqual(inventory.has(item), false);
-      assert.strictEqual(roomItems.has(item), true);
+      assert.strictEqual(inventory.has(item), true);
+      assert.strictEqual(roomItems.has(item), false);
       assert.deepStrictEqual(messages, [
         '<bold>Sanctum</bold>',
         'A quiet sanctum.',
         'The spike hums.',
       ]);
+      assert.ok(errors.some(message => message.includes('Bubble contribution attempted to enqueue mutation operations')));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
     }
   });
 
@@ -1414,6 +1435,337 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
+  it('executes postCommit broadcast selectors after render with phase counters', async function () {
+    const ranvierPath = require.resolve('ranvier');
+    const ranvier = require(ranvierPath);
+    const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalSayAtExcept = ranvier.Broadcast.sayAtExcept;
+    const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
+    const mutator = require(mutatorPath);
+    const originalApplyMutationPlan = mutator.applyMutationPlan;
+    const events = [];
+
+    ranvier.Broadcast.sayAt = (_target, message) => {
+      events.push(`sayAt:${String(message)}`);
+    };
+    ranvier.Broadcast.sayAtExcept = (_target, message, exceptTargets) => {
+      events.push(`sayAtExcept:${String(message)}:${Array.isArray(exceptTargets) ? exceptTargets.length : 0}`);
+    };
+    mutator.applyMutationPlan = () => {
+      events.push('commit');
+    };
+
+    try {
+      const roomTargets = [{ name: 'Tester' }, { name: 'Other' }];
+      const excludedRoomTargets = [{ name: 'Observer' }];
+      const excludedRoom = {
+        getBroadcastTargets: () => excludedRoomTargets,
+      };
+      const room = {
+        title: 'Selector Room',
+        description: 'Selector description',
+        area: {
+          getBroadcastTargets: () => roomTargets,
+        },
+        getBroadcastTargets: () => roomTargets,
+      };
+
+      const player = asPlayer({
+        name: 'Tester',
+        room,
+        socket: { writable: false },
+      });
+
+      const command = {
+        execute: async () => ({
+          ok: true,
+          plan: { operations: [{ type: 'noop' }] },
+          render: { lines: ['target render'] },
+          postCommit: [
+            { type: 'broadcast', audience: 'player', message: 'pc-player' },
+            { type: 'broadcast', audience: 'room', message: 'pc-room' },
+            { type: 'broadcast', audience: 'area', message: 'pc-area' },
+            { type: 'broadcast', audience: 'areaExceptTargets', message: 'pc-area-ex', exceptSelector: 'currentRoomTargets' },
+            { type: 'broadcast', audience: 'room', message: 'pc-room-by-ref', targetSelector: 'roomByRef', targetRoomRef: 'test:excluded-room' },
+            { type: 'broadcast', audience: 'areaExceptTargets', message: 'pc-area-ex-by-ref', exceptSelector: 'targetsByRoomRef', exceptRoomRef: 'test:excluded-room' },
+          ],
+        }),
+      };
+
+      const state = withPlayerManager({
+        CommandManager: { find: () => ({ command, alias: 'look' }) },
+        RoomManager: {
+          getRoom: (roomRef) => roomRef === 'test:excluded-room' ? excludedRoom : null,
+        },
+      }, player);
+
+      const trace = await handleCommand(state, { player }, 'look');
+
+      assert.deepStrictEqual(events, [
+        'commit',
+        'sayAt:target render',
+        'sayAt:pc-player',
+        'sayAt:pc-room',
+        'sayAt:pc-area',
+        'sayAtExcept:pc-area-ex:2',
+        'sayAt:pc-room-by-ref',
+        'sayAtExcept:pc-area-ex-by-ref:1',
+      ]);
+      assert.deepStrictEqual(trace.phases.postCommit, {
+        ok: true,
+        instructionsAttempted: 6,
+        failures: 0,
+      });
+    } finally {
+      ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Broadcast.sayAtExcept = originalSayAtExcept;
+      mutator.applyMutationPlan = originalApplyMutationPlan;
+    }
+  });
+
+  it('dispatches target postCommit before bubble postCommit entries', async function () {
+    const lookDef = require('../commands/look');
+    const ranvierPath = require.resolve('ranvier');
+    const ranvier = require(ranvierPath);
+    const originalSayAt = ranvier.Broadcast.sayAt;
+    const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
+    const mutator = require(mutatorPath);
+    const originalApplyMutationPlan = mutator.applyMutationPlan;
+    const messages = [];
+
+    ranvier.Broadcast.sayAt = (_target, message) => {
+      messages.push(String(message));
+    };
+    mutator.applyMutationPlan = () => { };
+
+    try {
+      const player = asPlayer({
+        name: 'Tester',
+        room: {
+          title: 'Queue Room',
+          description: 'Queue description',
+          area: {},
+          getBroadcastTargets: () => [],
+        },
+        socket: { writable: false },
+      });
+
+      const command = {
+        metadata: {
+          ...lookDef.metadata,
+          reactions: [
+            () => ({
+              postCommit: [
+                { type: 'broadcast', audience: 'player', message: 'bubble-1' },
+                { type: 'broadcast', audience: 'player', message: 'bubble-2' },
+              ],
+            }),
+          ],
+        },
+        execute: async () => ({
+          ok: true,
+          plan: { operations: [{ type: 'noop' }] },
+          render: { lines: ['target render'] },
+          postCommit: [
+            { type: 'broadcast', audience: 'player', message: 'target-post' },
+          ],
+        }),
+      };
+
+      const state = withPlayerManager({
+        CommandManager: { find: () => ({ command, alias: 'look' }) },
+      }, player);
+
+      await handleCommand(state, { player }, 'look');
+
+      assert.deepStrictEqual(messages, [
+        'target render',
+        'target-post',
+        'bubble-1',
+        'bubble-2',
+      ]);
+    } finally {
+      ranvier.Broadcast.sayAt = originalSayAt;
+      mutator.applyMutationPlan = originalApplyMutationPlan;
+    }
+  });
+
+  it('rejects unknown postCommit instruction types and continues remaining instructions', async function () {
+    const ranvierPath = require.resolve('ranvier');
+    const ranvier = require(ranvierPath);
+    const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
+    const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
+    const mutator = require(mutatorPath);
+    const originalApplyMutationPlan = mutator.applyMutationPlan;
+    const messages = [];
+    const errors = [];
+
+    ranvier.Broadcast.sayAt = (_target, message) => {
+      messages.push(String(message));
+    };
+    ranvier.Logger.error = message => {
+      errors.push(String(message));
+    };
+    mutator.applyMutationPlan = () => { };
+
+    try {
+      const player = asPlayer({
+        name: 'Tester',
+        room: { area: {}, getBroadcastTargets: () => [] },
+        socket: { writable: false },
+      });
+
+      const command = {
+        execute: async () => ({
+          ok: true,
+          plan: { operations: [{ type: 'noop' }] },
+          postCommit: [
+            { type: 'mystery', audience: 'player', message: 'bad' },
+            { type: 'broadcast', audience: 'player', message: 'good' },
+          ],
+        }),
+      };
+
+      const state = withPlayerManager({
+        CommandManager: { find: () => ({ command, alias: 'look' }) },
+      }, player);
+
+      const trace = await handleCommand(state, { player }, 'look');
+
+      assert.deepStrictEqual(messages, ['good']);
+      assert.ok(errors.some(message => message.includes('POST_COMMIT_DISPATCH: Unsupported postCommit instruction type')));
+      assert.deepStrictEqual(trace.phases.postCommit, {
+        ok: false,
+        instructionsAttempted: 2,
+        failures: 1,
+      });
+      assert.strictEqual(trace.outcome.ok, true);
+      assert.strictEqual(trace.outcome.code, 'OK');
+    } finally {
+      ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
+      mutator.applyMutationPlan = originalApplyMutationPlan;
+    }
+  });
+
+  it('rejects unknown bubble postCommit instruction types and continues remaining instructions', async function () {
+    const lookDef = require('../commands/look');
+    const ranvierPath = require.resolve('ranvier');
+    const ranvier = require(ranvierPath);
+    const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
+    const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
+    const mutator = require(mutatorPath);
+    const originalApplyMutationPlan = mutator.applyMutationPlan;
+    const messages = [];
+    const errors = [];
+
+    ranvier.Broadcast.sayAt = (_target, message) => {
+      messages.push(String(message));
+    };
+    ranvier.Logger.error = message => {
+      errors.push(String(message));
+    };
+    mutator.applyMutationPlan = () => { };
+
+    try {
+      const player = asPlayer({
+        name: 'Tester',
+        room: {
+          title: 'Bubble PostCommit',
+          description: 'Room line',
+          area: {},
+          getBroadcastTargets: () => [],
+        },
+        socket: { writable: false },
+      });
+
+      const command = {
+        metadata: {
+          ...lookDef.metadata,
+          reactions: [
+            () => ({
+              postCommit: [
+                { type: 'mystery', audience: 'player', message: 'bad' },
+                { type: 'broadcast', audience: 'player', message: 'bubble-good' },
+              ],
+            }),
+          ],
+        },
+        execute: lookDef.command({}),
+      };
+
+      const state = withPlayerManager({
+        CommandManager: { find: () => ({ command, alias: 'look' }) },
+      }, player);
+
+      const trace = await handleCommand(state, { player }, 'look');
+
+      assert.ok(messages.includes('bubble-good'));
+      assert.ok(errors.some(message => message.includes('POST_COMMIT_DISPATCH: Unsupported postCommit instruction type')));
+      assert.deepStrictEqual(trace.phases.postCommit, {
+        ok: false,
+        instructionsAttempted: 2,
+        failures: 1,
+      });
+    } finally {
+      ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
+      mutator.applyMutationPlan = originalApplyMutationPlan;
+    }
+  });
+
+  it('does not execute postCommit instructions when commit fails', async function () {
+    const ranvierPath = require.resolve('ranvier');
+    const ranvier = require(ranvierPath);
+    const originalSayAt = ranvier.Broadcast.sayAt;
+    const originalLoggerError = ranvier.Logger.error;
+    const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
+    const mutator = require(mutatorPath);
+    const originalApplyMutationPlan = mutator.applyMutationPlan;
+    const messages = [];
+
+    ranvier.Broadcast.sayAt = (_target, message) => {
+      messages.push(String(message));
+    };
+    ranvier.Logger.error = () => { };
+    mutator.applyMutationPlan = () => {
+      throw new Error('commit failed');
+    };
+
+    try {
+      const player = asPlayer({
+        name: 'Tester',
+        room: { area: {}, getBroadcastTargets: () => [] },
+        socket: { writable: false },
+      });
+
+      const command = {
+        execute: async () => ({
+          ok: true,
+          plan: { operations: [{ type: 'noop' }] },
+          postCommit: [
+            { type: 'broadcast', audience: 'player', message: 'should not emit' },
+          ],
+        }),
+      };
+
+      const state = withPlayerManager({
+        CommandManager: { find: () => ({ command, alias: 'look' }) },
+      }, player);
+
+      const trace = await handleCommand(state, { player }, 'look');
+
+      assert.ok(!messages.includes('should not emit'));
+      assert.strictEqual(trace.phases.postCommit, undefined);
+    } finally {
+      ranvier.Broadcast.sayAt = originalSayAt;
+      ranvier.Logger.error = originalLoggerError;
+      mutator.applyMutationPlan = originalApplyMutationPlan;
+    }
+  });
+
   it('ignores non-operation bubble return values', async function () {
     const lookDef = require('../commands/look');
     const ranvierPath = require.resolve('ranvier');
@@ -1463,7 +1815,7 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('merges bubble operations into commit plan', async function () {
+  it('ignores legacy single-operation bubble shape and keeps target plan unchanged', async function () {
     const mutatorPath = path.resolve(__dirname, '../lib/session/mutator.js');
     const mutator = require(mutatorPath);
     const originalApplyMutationPlan = mutator.applyMutationPlan;
@@ -1500,7 +1852,7 @@ describe('bundle-rantamuta command-dispatch', function () {
       await handleCommand(state, { player }, 'look');
 
       assert.ok(committedPlan);
-      assert.deepStrictEqual(committedPlan.operations, [{ type: 'noop' }, { type: 'noop' }]);
+      assert.deepStrictEqual(committedPlan.operations, [{ type: 'noop' }]);
     } finally {
       mutator.applyMutationPlan = originalApplyMutationPlan;
     }
@@ -1721,7 +2073,7 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('vetoes wrong ritual offering via indirect target allowAction hook', async function () {
+  it('vetoes wrong offering via indirect target allowAction hook', async function () {
     const putDef = require('../commands/put');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
@@ -1743,16 +2095,16 @@ describe('bundle-rantamuta command-dispatch', function () {
 
     try {
       const wrongItem = {
-        uuid: 'wax-1',
-        entityReference: 'rantamuta:waxSeal',
-        name: 'wax seal',
-        keywords: ['wax', 'seal'],
+        uuid: 'cog-1',
+        entityReference: 'test:tinCog',
+        name: 'tin cog',
+        keywords: ['tin', 'cog'],
       };
-      const bell = {
-        uuid: 'bell-1',
-        entityReference: 'rantamuta:crackedBell',
-        name: 'cracked bell',
-        keywords: ['cracked', 'bell'],
+      const socket = {
+        uuid: 'socket-1',
+        entityReference: 'test:mechanismSocket',
+        name: 'mechanism socket',
+        keywords: ['mechanism', 'socket'],
         type: 'CONTAINER',
         maxItems: 1,
         inventory: new Map(),
@@ -1762,11 +2114,11 @@ describe('bundle-rantamuta command-dispatch', function () {
           }
 
           const direct = context && context.entityResolution && context.entityResolution.directTarget;
-          if (direct && direct.entityReference === 'rantamuta:bronzeClapper') {
+          if (direct && direct.entityReference === 'test:powerCrystal') {
             return undefined;
           }
 
-          return 'That does not belong in the bell.';
+          return 'That does not belong in the mechanism socket.';
         },
         addItem() { },
         removeItem() { },
@@ -1774,7 +2126,7 @@ describe('bundle-rantamuta command-dispatch', function () {
       const player = asPlayer({
         name: 'Tester',
         inventory: new Map([[wrongItem.uuid, wrongItem]]),
-        room: { items: new Set([bell]) },
+        room: { items: new Set([socket]) },
         addItem() { },
         removeItem() { },
         socket: { writable: false },
@@ -1788,10 +2140,10 @@ describe('bundle-rantamuta command-dispatch', function () {
         CommandManager: { find: () => ({ command, alias: 'put' }) },
       }, player);
 
-      await handleCommand(state, { player }, 'put wax seal in cracked bell');
+      await handleCommand(state, { player }, 'put tin cog in mechanism socket');
 
       assert.strictEqual(mutatorCalled, false);
-      assert.ok(messages.includes('That does not belong in the bell.'));
+      assert.ok(messages.includes('That does not belong in the mechanism socket.'));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
       ranvier.Broadcast.prompt = originalPrompt;
@@ -1799,7 +2151,7 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('renders ritual flavor line from indirect target bubbleEvent hook on correct offering', async function () {
+  it('renders flavor line from indirect target bubbleEvent hook on correct offering', async function () {
     const putDef = require('../commands/put');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
@@ -1817,17 +2169,17 @@ describe('bundle-rantamuta command-dispatch', function () {
     mutator.applyMutationPlan = () => { };
 
     try {
-      const clapper = {
-        uuid: 'clapper-1',
-        entityReference: 'rantamuta:bronzeClapper',
-        name: 'bronze clapper',
-        keywords: ['bronze', 'clapper'],
+      const crystal = {
+        uuid: 'crystal-1',
+        entityReference: 'test:powerCrystal',
+        name: 'power crystal',
+        keywords: ['power', 'crystal'],
       };
-      const bell = {
-        uuid: 'bell-2',
-        entityReference: 'rantamuta:crackedBell',
-        name: 'cracked bell',
-        keywords: ['cracked', 'bell'],
+      const socket = {
+        uuid: 'socket-2',
+        entityReference: 'test:mechanismSocket',
+        name: 'mechanism socket',
+        keywords: ['mechanism', 'socket'],
         type: 'CONTAINER',
         maxItems: 1,
         inventory: new Map(),
@@ -1837,13 +2189,13 @@ describe('bundle-rantamuta command-dispatch', function () {
           }
 
           const direct = context && context.entityResolution && context.entityResolution.directTarget;
-          if (!direct || direct.entityReference !== 'rantamuta:bronzeClapper') {
+          if (!direct || direct.entityReference !== 'test:powerCrystal') {
             return null;
           }
 
           return {
             render: {
-              lines: ['The cracked bell hums with a low resonance.'],
+              lines: ['The mechanism emits a steady tone.'],
             },
           };
         },
@@ -1852,8 +2204,8 @@ describe('bundle-rantamuta command-dispatch', function () {
       };
       const player = asPlayer({
         name: 'Tester',
-        inventory: new Map([[clapper.uuid, clapper]]),
-        room: { items: new Set([bell]) },
+        inventory: new Map([[crystal.uuid, crystal]]),
+        room: { items: new Set([socket]) },
         addItem() { },
         removeItem() { },
         socket: { writable: false },
@@ -1867,10 +2219,10 @@ describe('bundle-rantamuta command-dispatch', function () {
         CommandManager: { find: () => ({ command, alias: 'put' }) },
       }, player);
 
-      await handleCommand(state, { player }, 'put bronze clapper in cracked bell');
+      await handleCommand(state, { player }, 'put power crystal in mechanism socket');
 
-      assert.ok(messages.includes('You put the bronze clapper in the cracked bell.'));
-      assert.ok(messages.includes('The cracked bell hums with a low resonance.'));
+      assert.ok(messages.includes('You put the power crystal in the mechanism socket.'));
+      assert.ok(messages.includes('The mechanism emits a steady tone.'));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
       ranvier.Broadcast.prompt = originalPrompt;
@@ -2469,9 +2821,8 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('blocks go down via bell crypt room script until required placements exist', async function () {
+  it('blocks go down via room allowAction gate until required placements exist', async function () {
     const goDef = require('../commands/go');
-    const bellCryptGateScript = require('../areas/rantamuta/scripts/rooms/bellCryptGate');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
     const originalSayAt = ranvier.Broadcast.sayAt;
@@ -2492,29 +2843,56 @@ describe('bundle-rantamuta command-dispatch', function () {
 
     try {
       const destination = {
-        entityReference: 'rantamuta:resonance_chamber',
-        title: 'Resonance Chamber',
-        description: 'A hidden chamber.',
+        entityReference: 'test:lowerVault',
+        title: 'Lower Vault',
+        description: 'A sealed lower vault.',
         items: new Set(),
         getDoor: () => null,
       };
       const room = {
-        entityReference: 'rantamuta:bell_crypt',
+        entityReference: 'test:upperVault',
         getExits: () => [{
           direction: 'down',
           roomId: destination.entityReference,
           metadata: {
             gate: {
-              denyMessage: 'A dull stone slab blocks the descent.',
+              denyMessage: 'A reinforced hatch blocks the descent.',
               requiredPlacements: [
-                { containerRef: 'rantamuta:crackedBell', itemRef: 'rantamuta:bronzeClapper' },
+                { containerRef: 'test:controlSocket', itemRef: 'test:powerCrystal' },
               ],
             },
           },
         }],
+        allowAction(action, context) {
+          if (!action || action.verbId !== 'go' || action.role !== null) {
+            return undefined;
+          }
+
+          const directTarget = context && context.entityResolution && context.entityResolution.directTarget;
+          const gate = directTarget && directTarget.metadata && directTarget.metadata.gate;
+          if (!gate) {
+            return undefined;
+          }
+
+          const required = Array.isArray(gate.requiredPlacements) ? gate.requiredPlacements : [];
+          const denyMessage = typeof gate.denyMessage === 'string' ? gate.denyMessage : 'You can\'t go that way.';
+          const items = state && state.ItemManager && state.ItemManager.items
+            ? Array.from(state.ItemManager.items)
+            : [];
+          const hasAll = required.every(requirement => {
+            const container = items.find(item => item && item.entityReference === requirement.containerRef);
+            if (!container || !container.inventory || typeof container.inventory.values !== 'function') {
+              return false;
+            }
+
+            return Array.from(container.inventory.values()).some(item => item && item.entityReference === requirement.itemRef);
+          });
+
+          return hasAll ? undefined : denyMessage;
+        },
       };
-      const crackedBell = {
-        entityReference: 'rantamuta:crackedBell',
+      const controlSocket = {
+        entityReference: 'test:controlSocket',
         inventory: new Map(),
       };
       const command = {
@@ -2527,9 +2905,8 @@ describe('bundle-rantamuta command-dispatch', function () {
       };
       const state = withPlayerManager({
         CommandManager: { find: () => ({ command, alias: 'go' }) },
-        ItemManager: { items: new Set([crackedBell]) },
+        ItemManager: { items: new Set([controlSocket]) },
       }, null);
-      bellCryptGateScript.listeners.spawn(state).call(room);
 
       const player = asPlayer({
         name: 'Tester',
@@ -2542,7 +2919,7 @@ describe('bundle-rantamuta command-dispatch', function () {
       await handleCommand(state, { player }, 'go down');
 
       assert.strictEqual(mutatorCalled, false);
-      assert.ok(messages.includes('A dull stone slab blocks the descent.'));
+      assert.ok(messages.includes('A reinforced hatch blocks the descent.'));
     } finally {
       ranvier.Broadcast.sayAt = originalSayAt;
       ranvier.Broadcast.prompt = originalPrompt;
@@ -2550,9 +2927,8 @@ describe('bundle-rantamuta command-dispatch', function () {
     }
   });
 
-  it('allows go down via bell crypt room script when required placements are satisfied', async function () {
+  it('allows go down via room allowAction gate when required placements are satisfied', async function () {
     const goDef = require('../commands/go');
-    const bellCryptGateScript = require('../areas/rantamuta/scripts/rooms/bellCryptGate');
     const ranvierPath = require.resolve('ranvier');
     const ranvier = require(ranvierPath);
     const originalSayAt = ranvier.Broadcast.sayAt;
@@ -2570,31 +2946,58 @@ describe('bundle-rantamuta command-dispatch', function () {
 
     try {
       const destination = {
-        entityReference: 'rantamuta:resonance_chamber',
-        title: 'Resonance Chamber',
-        description: 'A hidden chamber.',
+        entityReference: 'test:lowerVault',
+        title: 'Lower Vault',
+        description: 'A sealed lower vault.',
         items: new Set(),
         getDoor: () => null,
       };
-      const clapper = { entityReference: 'rantamuta:bronzeClapper' };
-      const crackedBell = {
-        entityReference: 'rantamuta:crackedBell',
-        inventory: new Map([['clapper-1', clapper]]),
+      const crystal = { entityReference: 'test:powerCrystal' };
+      const controlSocket = {
+        entityReference: 'test:controlSocket',
+        inventory: new Map([['crystal-1', crystal]]),
       };
       const room = {
-        entityReference: 'rantamuta:bell_crypt',
+        entityReference: 'test:upperVault',
         getExits: () => [{
           direction: 'down',
           roomId: destination.entityReference,
           metadata: {
             gate: {
-              denyMessage: 'A dull stone slab blocks the descent.',
+              denyMessage: 'A reinforced hatch blocks the descent.',
               requiredPlacements: [
-                { containerRef: 'rantamuta:crackedBell', itemRef: 'rantamuta:bronzeClapper' },
+                { containerRef: 'test:controlSocket', itemRef: 'test:powerCrystal' },
               ],
             },
           },
         }],
+        allowAction(action, context) {
+          if (!action || action.verbId !== 'go' || action.role !== null) {
+            return undefined;
+          }
+
+          const directTarget = context && context.entityResolution && context.entityResolution.directTarget;
+          const gate = directTarget && directTarget.metadata && directTarget.metadata.gate;
+          if (!gate) {
+            return undefined;
+          }
+
+          const required = Array.isArray(gate.requiredPlacements) ? gate.requiredPlacements : [];
+          const denyMessage = typeof gate.denyMessage === 'string' ? gate.denyMessage : 'You can\'t go that way.';
+          const items = state && state.ItemManager && state.ItemManager.items
+            ? Array.from(state.ItemManager.items)
+            : [];
+          const hasAll = required.every(requirement => {
+            const container = items.find(item => item && item.entityReference === requirement.containerRef);
+            if (!container || !container.inventory || typeof container.inventory.values !== 'function') {
+              return false;
+            }
+
+            return Array.from(container.inventory.values()).some(item => item && item.entityReference === requirement.itemRef);
+          });
+
+          return hasAll ? undefined : denyMessage;
+        },
       };
       const command = {
         metadata: goDef.metadata,
@@ -2606,9 +3009,8 @@ describe('bundle-rantamuta command-dispatch', function () {
       };
       const state = withPlayerManager({
         CommandManager: { find: () => ({ command, alias: 'go' }) },
-        ItemManager: { items: new Set([crackedBell, clapper]) },
+        ItemManager: { items: new Set([controlSocket, crystal]) },
       }, null);
-      bellCryptGateScript.listeners.spawn(state).call(room);
 
       const player = asPlayer({
         name: 'Tester',

--- a/tests/scenarios/scenario.bell-tower.test.js
+++ b/tests/scenarios/scenario.bell-tower.test.js
@@ -50,6 +50,15 @@ test('bell tower puzzle runs successfully end to end', () => {
   assert.ok(downRun);
   assert.equal(downRun.parse.canonicalInput, 'go down');
 
+  const ritualCompletionRun = runEvents.find(event => event.raw === 'put bronze clapper in cracked bell');
+  assert.ok(ritualCompletionRun);
+  assert.ok(ritualCompletionRun.phases);
+  assert.deepStrictEqual(ritualCompletionRun.phases.postCommit, {
+    ok: true,
+    instructionsAttempted: 3,
+    failures: 0,
+  });
+
   const outputText = payload.events
     .filter(event => event.type === 'output')
     .map(event => stripAnsi(String(event.text)))


### PR DESCRIPTION
This PR introduces a dispatcher-owned post-commit delivery queue for command execution and tightens Bubble semantics to keep mutation strictly in Commit.

## What changed
- Added `lib/session/post-commit-dispatch.js`:
  - Executes `postCommit` instructions after successful commit + render.
  - Supports broadcast-only instructions (`type: 'broadcast'`).
  - Uses selector-based targeting (`currentPlayer`, `currentRoom`, `currentArea`, `roomByRef`, `currentRoomTargets`, `targetsByRoomRef`).
  - Treats invalid instructions as best-effort failures (log + continue).
- Updated `lib/session/command-dispatch.js`:
  - Bubble now accepts only data contributions (`render.lines`, `postCommit`).
  - Bubble `operations` are rejected/ignored with contract-error logging.
  - Success ordering is now: commit -> render -> postCommit -> prompt.
  - PostCommit merge order is deterministic: command `postCommit` first, then bubble `postCommit`.
  - Added postCommit trace phase stats (`instructionsAttempted`, `failures`, `ok`).
- Migrated Bell Tower ritual broadcast path:
  - Removed direct broadcast side effects from room script wrappers.
  - Ritual completion now enqueues postCommit broadcasts from area script data.
- Enforced layering boundary:
  - Runtime post-commit dispatcher is content-agnostic.
  - Area-specific refs stay in area scripts as data payloads.
- Fixed player typing/runtime safety:
  - New player creation now supplies required `password` field in `player-lifecycle.js`.

## Tests
- Expanded `tests/command.dispatch.test.js` for:
  - forbidden Bubble operations behavior,
  - postCommit selector routing,
  - queue ordering,
  - commit-failure suppression of postCommit,
  - unknown instruction fail-and-continue behavior.
- Updated `tests/scenarios/scenario.bell-tower.test.js` to assert postCommit phase counters on ritual completion.
- Kept command dispatch test fixtures content-generic (no Bell Tower theming).

## Docs
- Updated `docs/normative/CommandArchitecture.md` with Bubble/Commit/PostCommit contract changes.
- Updated `docs/BundleRantamutaTechnicalManual.md` with postCommit DSL and ordering.
- Updated `docs/prompts/agents/verb.md` guardrails for broadcast-only postCommit and non-mutating Bubble.
- Added layering boundary guidance in `AGENTS.md`.

## Validation
- `cd bundles/bundle-rantamuta && npm test -- --runInBand` ✅
- `npm test` ✅
- `npm run ci:local` blocked by dirty-tree guard (expected in current workspace state).
